### PR TITLE
Fix (dialog): handle quick close (progress dialogs)

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Aurelia</title>
-    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.5.0/css/font-awesome.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body aurelia-app="src/main">

--- a/sample/src/app.html
+++ b/sample/src/app.html
@@ -1,7 +1,14 @@
 <template>
   <button click.trigger="submit()">Open Modal</button>
-  <button style="position: absolute; top: 100px; left: 50px;" click.trigger="positionManually($event)">Open Next To Me</button>
+  <button style="position: absolute; top: 200px; left: 50px;" click.trigger="positionManually($event)">Open Next To Me</button>
   <input type="checkbox" checked.bind="showExtraData" /> Fill the modal with extra stuff (scrolling and sizing text)
+
+  <h3>Progress dialogs</h3>
+
+  <button click.trigger="slowProgress($event)">Slow Progress</button>
+  <button click.trigger="faultyProgress($event)">Faulty Progress</button>
+  <button click.trigger="fastProgress($event)">Fast Progress</button>
+  <button click.trigger="fastestProgress($event)">Fastest Progress</button>
 
 <div style="width: 300px; margin: 0 auto;">
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut at sagittis augue. Integer sed mi tincidunt, facilisis lorem sit amet, ullamcorper augue. Morbi a dignissim lectus. In euismod neque ut condimentum venenatis. Pellentesque a urna ipsum. Nunc vel leo in felis placerat mattis. Quisque sit amet est id lacus condimentum aliquam. Aliquam erat volutpat. Sed lacinia sagittis nisi. Nulla facilisi.

--- a/sample/src/app.js
+++ b/sample/src/app.js
@@ -1,6 +1,7 @@
 import {inject} from 'aurelia-framework';
 import {DialogService} from 'aurelia-dialog';
 import {EditPerson} from './edit-person';
+import {Progress} from './progress';
 
 @inject(DialogService)
 export class App {
@@ -45,5 +46,96 @@ export class App {
         console.log('bad');
       }
     });
+  }
+
+
+
+  slowProgress(e) {
+    let progressOptions = {
+      waitMessage: "Fetching slow data"
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 500,
+      progressPercentIncrease: 20
+    }
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  faultyProgress(e) {
+    alert('Faulty as it closes synchronously instead of after the open promise.'
+      + ' If pressed first, the close will fail and the console will log the caught promise error "TypeError: dialogController.hideDialog is not a function".'
+      + ' If another button is pressed first, it will silently fail to destroy the dialog, leaving ai-dialog-overlay hidden but still blocking.')
+
+    let progressOptions = {
+      waitMessage: "Fetching fast data",
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 0,            //faster than transitionEnd event, so open is not completed.
+      progressPercentIncrease: 100
+    }
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  fastProgress(e) {
+    let progressOptions = {
+      waitMessage: "Fetching fast data",
+    };
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    let process = {
+      progressInterval: 0,
+      progressPercentIncrease: 100,
+      terminateProgressDailog: () => {
+        //have to let renderer completely build controller, so
+        progressOptions.showDialogPromise.then(() => {
+          progressOptions.closeDialog();
+        });
+      }
+    }
+
+    setTimeout(this.incrementProgress, process.progressInterval, this, process, progressOptions);
+  }
+
+  fastestProgress(e) {
+    let progressOptions = {
+      waitMessage: "Get data now"
+    };
+
+    this.dialogService.open({
+      viewModel: Progress,
+      model: progressOptions
+    });
+
+    //no timeout progress, straight to close
+    progressOptions.showDialogPromise.then(() => {
+      progressOptions.closeDialog();
+    });
+  }
+
+
+  incrementProgress(that, process, progressOptions) {
+    let completedPercent = progressOptions.incrementProgress(process.progressPercentIncrease);
+    if (completedPercent < 100) {
+      setTimeout(that.incrementProgress, process.progressInterval, that, process, progressOptions);
+    } else {
+      if (process.terminateProgressDailog) {
+        process.terminateProgressDailog();
+      } else {
+        progressOptions.closeDialog();
+      }
+    }
   }
 }

--- a/sample/src/progress.css
+++ b/sample/src/progress.css
@@ -1,0 +1,18 @@
+.progress-bar {
+  background-color: black;
+  border-radius: 13px; /* (height of inner div) / 2 + padding */
+  padding: 3px;
+}
+
+.progress-bar > div {
+  background-color: orange;
+  width: 0%;
+  height: 20px;
+  border-radius: 10px;
+}
+
+.progress-message {
+  text-align: center;
+  margin: 18px;
+  font-size: 20px;
+}

--- a/sample/src/progress.html
+++ b/sample/src/progress.html
@@ -1,0 +1,17 @@
+<template>
+  <require from='./progress.css'></require>
+  <ai-dialog>
+    <ai-dialog-body>
+      <div class='blockPageDialog'>
+        <div class='progress-message'>${waitMessage}</div>
+        <!-- <i class="fa fa-spinner fa-spin"></i>  -->
+        <div class="progress-bar progress">
+          <div css="width: ${completedPercent}%"></div>
+        </div>
+      </div>
+    </ai-dialog-body>
+    <ai-dialog-footer>
+      <button click.trigger="controller.cancel()">Cancel</button>
+    </ai-dialog-footer>
+  </ai-dialog>
+</template>

--- a/sample/src/progress.js
+++ b/sample/src/progress.js
@@ -1,0 +1,29 @@
+import {DialogController} from 'aurelia-dialog';
+
+export class Progress {
+  static inject = [DialogController];
+
+  constructor(controller) {
+    this.controller = controller;
+  }
+
+  activate(progressOptions) {
+    this.progressOptions = progressOptions;
+    this.waitMessage = progressOptions.waitMessage || 'Waiting';
+    this.completedPercent = 0;
+
+    let that = this;
+    progressOptions.incrementProgress = (percentIncrease) => {
+      that.completedPercent += percentIncrease;
+      return that.completedPercent;
+    }
+
+    progressOptions.closeDialog = () => {
+      that.controller.close(true, null)
+        .catch((error) => {
+          //dont care if close failed
+          console.log("Error: controller.close threw error: " + error);
+        });
+    }
+  }
+}

--- a/src/dialog-options.js
+++ b/src/dialog-options.js
@@ -1,5 +1,11 @@
+
+/**
+ * Dialog Options for end consumer
+ * @param showDialogTimeout Should be just greater than dialog.css ai-dialog-container transition duration.
+ */
 export let dialogOptions = {
   lock: true,
   centerHorizontalOnly: false,
-  startingZIndex: 1000
+  startingZIndex: 1000,
+  showDialogTimeout: 250
 };

--- a/test/unit/dialog-renderer.spec.js
+++ b/test/unit/dialog-renderer.spec.js
@@ -10,12 +10,14 @@ initialize();
 let defaultSettings = {
   lock: true,
   centerHorizontalOnly: false,
-  startingZIndex: 1000
+  startingZIndex: 1000,
+  showDialogTimeout: 250
 };
 let newSettings = {
   lock: false,
   centerHorizontalOnly: true,
-  startingZIndex: 1
+  startingZIndex: 1,
+  showDialogTimeout: 300
 };
 
 let frameworkConfig = {


### PR DESCRIPTION
Progress dialogs are closed by code, and can be unpredictably closed
very quickly

Ensure show & close are always completed.
add options.showDialogTimeout
return model.showDialogPromise
